### PR TITLE
Implement minimal vanilla JS SPA todo list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SPA To-do Liste</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="todo-app">
+    <h1 class="app-title">Meine Aufgaben</h1>
+    <form id="todo-form" class="todo-form">
+      <input type="text" id="todo-input" class="todo-input" maxlength="200" placeholder="Neue Aufgabe" aria-label="Neuer Task">
+      <button type="submit" id="add-button" class="add-button" disabled>Hinzufügen</button>
+    </form>
+    <ul id="todo-list" class="todo-list"></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Array zum Speichern aller Aufgaben
+const tasks = [];
+
+// DOM-Referenzen
+const form = document.getElementById('todo-form');
+const input = document.getElementById('todo-input');
+const addButton = document.getElementById('add-button');
+const list = document.getElementById('todo-list');
+
+// Aktiviert/Deaktiviert den Button je nach Eingabefeldinhalt
+input.addEventListener('input', () => {
+  addButton.disabled = input.value.trim().length === 0;
+});
+
+// Erstellt eine neue Aufgabe im vorgegebenen Datenmodell
+function createTask(text) {
+  return {
+    id: crypto.randomUUID(), // uuid-v4 erzeugen
+    text,
+    priority: 0,
+    createdAt: new Date().toISOString(),
+    doneAt: null,
+    isDone: false,
+    order: tasks.length
+  };
+}
+
+// Fügt eine Aufgabe der Liste und dem DOM hinzu
+function addTask(task) {
+  tasks.push(task);
+
+  const item = document.createElement('li');
+  item.textContent = task.text;
+  list.appendChild(item);
+}
+
+// Verhindert das Standardverhalten des Formulars und erstellt eine Aufgabe
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+
+  const text = input.value.trim();
+  if (!text) return;
+
+  const task = createTask(text);
+  addTask(task);
+
+  // Eingabefeld leeren und Button deaktivieren
+  input.value = '';
+  addButton.disabled = true;
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,59 @@
+/* Grundlegendes Layout für die To-do App */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+
+.todo-app {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  margin-top: 0;
+  text-align: center;
+}
+
+.todo-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.todo-input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.add-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.todo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.todo-list li {
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- add base HTML skeleton
- style the todo app
- implement JS logic to add tasks

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684b3086c15c8331a1e9dd1e6eef1c2e