### PR TITLE
Add priority selection and badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SPA To-do Liste</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="todo-app">
+    <h1 class="app-title">Meine Aufgaben</h1>
+    <nav class="nav">
+      <a href="#/" id="link-open" class="nav-link">Offen</a>
+      <a href="#/done" id="link-done" class="nav-link">Erledigt</a>
+    </nav>
+    <form id="todo-form" class="todo-form">
+      <input type="text" id="todo-input" class="todo-input" maxlength="200" placeholder="Neue Aufgabe" aria-label="Neuer Task">
+      <select id="priority-select" class="priority-select" aria-label="Priorität">
+        <option value="low" selected>Niedrig</option>
+        <option value="medium">Mittel</option>
+        <option value="high">Hoch</option>
+      </select>
+      <button type="submit" id="add-button" class="add-button" disabled>Hinzufügen</button>
+    </form>
+    <ul id="todo-list" class="todo-list"></ul>
+    <ul id="done-list" class="done-list" hidden></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,141 @@
+/* Grundlegendes Layout für die To-do App */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+
+.todo-app {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  margin-top: 0;
+  text-align: center;
+}
+
+.todo-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.todo-input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.priority-select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.add-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.todo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.todo-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+/* Abstand fuer die Checkbox */
+.task-checkbox {
+  margin-right: 0.5rem;
+}
+
+/* Navigation zwischen den Routen */
+.nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.nav-link {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.nav-link.active {
+  font-weight: bold;
+}
+
+/* Liste fuer erledigte Aufgaben */
+.done-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.done-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.done-list time {
+  display: block;
+  font-size: 0.8rem;
+  color: #666;
+}
+
+/* Button zum Wiederherstellen einer Aufgabe */
+.restore-button {
+  margin-left: auto;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: #007bff;
+  font-size: 1rem;
+}
+
+/* Farbige Badges fuer die Prioritaet */
+.priority-badge {
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #fff;
+}
+
+.priority-high {
+  background-color: #dc3545;
+}
+
+.priority-medium {
+  background-color: #ffc107;
+  color: #000;
+}
+
+.priority-low {
+  background-color: #28a745;
+}


### PR DESCRIPTION
## Summary
- add priority drop-down in the task form
- style priority select and colored badges for tasks
- persist priority in tasks and display badges in open and done lists

## Testing
- `npm run evaluate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684b3086c15c8331a1e9dd1e6eef1c2e