### PR TITLE
Add theme toggle to todo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SPA To-do Liste</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="app-header">
+    <button id="theme-toggle" class="theme-toggle" aria-label="Theme umschalten">🌙</button>
+  </header>
+  <main class="todo-app">
+    <h1 class="app-title">Meine Aufgaben</h1>
+    <nav class="nav">
+      <a href="#/" id="link-open" class="nav-link">Offen</a>
+      <a href="#/done" id="link-done" class="nav-link">Erledigt</a>
+    </nav>
+    <form id="todo-form" class="todo-form">
+      <input type="text" id="todo-input" class="todo-input" maxlength="200" placeholder="Neue Aufgabe" aria-label="Neuer Task">
+      <select id="priority-select" class="priority-select" aria-label="Priorität">
+        <option value="low" selected>Niedrig</option>
+        <option value="medium">Mittel</option>
+        <option value="high">Hoch</option>
+      </select>
+      <button type="submit" id="add-button" class="add-button" disabled>Hinzufügen</button>
+    </form>
+    <ul id="todo-list" class="todo-list"></ul>
+    <ul id="done-list" class="done-list" hidden></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,365 @@
+'use strict';
+
+// Array zum Speichern aller Aufgaben
+const tasks = [];
+
+// Placeholder-Element fuer Drag-and-Drop
+const placeholder = document.createElement('li');
+placeholder.className = 'placeholder';
+
+let draggedItem = null;
+let keyboardMode = false;
+
+// Speichert das Aufgaben-Array in localStorage
+function saveTasks() {
+  localStorage.setItem('todoTasks', JSON.stringify(tasks));
+}
+
+// Laedt Aufgaben aus localStorage und befuellt das Array
+function loadTasks() {
+  const data = localStorage.getItem('todoTasks');
+  if (!data) return;
+  try {
+    const parsed = JSON.parse(data);
+    if (Array.isArray(parsed)) {
+      parsed.forEach(t => {
+        if (!t.priority) t.priority = 'low';
+        if (typeof t.order !== 'number') t.order = tasks.length;
+        tasks.push(t);
+      });
+      tasks.sort((a, b) => a.order - b.order);
+    }
+  } catch (err) {
+    console.error('Fehler beim Laden der Aufgaben', err);
+  }
+}
+
+// DOM-Referenzen
+const form = document.getElementById('todo-form');
+const input = document.getElementById('todo-input');
+const prioritySelect = document.getElementById('priority-select');
+const addButton = document.getElementById('add-button');
+const list = document.getElementById('todo-list');
+const doneList = document.getElementById('done-list');
+const linkOpen = document.getElementById('link-open');
+const linkDone = document.getElementById('link-done');
+const themeToggle = document.getElementById('theme-toggle');
+
+// Wendet das gegebene Theme an und aktualisiert den Toggle-Button
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+  themeToggle.textContent = theme === 'dark' ? '🌙' : '☀️';
+}
+
+// Laedt das gespeicherte Theme oder folgt den Systemeinstellungen
+function loadTheme() {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') {
+    applyTheme(stored);
+  } else {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyTheme(prefersDark ? 'dark' : 'light');
+  }
+}
+
+list.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  const target = e.target.closest('.task-item');
+  if (!target || target === placeholder || target === draggedItem) return;
+  const rect = target.getBoundingClientRect();
+  const offset = e.clientY - rect.top;
+  if (offset > rect.height / 2) {
+    target.after(placeholder);
+  } else {
+    target.before(placeholder);
+  }
+});
+
+list.addEventListener('drop', (e) => {
+  e.preventDefault();
+  if (!draggedItem) return;
+  placeholder.replaceWith(draggedItem);
+  draggedItem.classList.remove('dragging');
+  updateOrder();
+  saveTasks();
+  draggedItem = null;
+});
+
+// Aktiviert/Deaktiviert den Button je nach Eingabefeldinhalt
+input.addEventListener('input', () => {
+  addButton.disabled = input.value.trim().length === 0;
+});
+
+// Erstellt eine neue Aufgabe im vorgegebenen Datenmodell
+function createTask(text, priority) {
+  return {
+    id: crypto.randomUUID(), // uuid-v4 erzeugen
+    text,
+    priority,
+    createdAt: new Date().toISOString(),
+    doneAt: null,
+    isDone: false,
+    order: tasks.length
+  };
+}
+
+// Erstellt ein Listenelement mit Checkbox und Event-Handler
+function renderTask(task) {
+  const item = document.createElement('li');
+  item.className = 'task-item';
+  item.draggable = true;
+  item.dataset.id = task.id;
+  item.tabIndex = 0;
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.className = 'task-checkbox';
+
+  item.addEventListener('dragstart', (e) => {
+    draggedItem = item;
+    placeholder.style.height = `${item.offsetHeight}px`;
+    item.classList.add('dragging');
+    e.dataTransfer.effectAllowed = 'move';
+  });
+
+  item.addEventListener('dragend', () => {
+    item.classList.remove('dragging');
+    if (placeholder.parentNode) placeholder.remove();
+    draggedItem = null;
+  });
+
+  item.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!keyboardMode) {
+        keyboardMode = true;
+        draggedItem = item;
+        placeholder.style.height = `${item.offsetHeight}px`;
+        item.after(placeholder);
+        item.classList.add('dragging');
+      } else {
+        const moveTarget = e.key === 'ArrowUp' ? placeholder.previousElementSibling : placeholder.nextElementSibling;
+        if (moveTarget && moveTarget !== item) {
+          if (e.key === 'ArrowUp') {
+            moveTarget.before(placeholder);
+          } else {
+            moveTarget.after(placeholder);
+          }
+        }
+      }
+    } else if (e.key === 'Enter' && keyboardMode) {
+      e.preventDefault();
+      placeholder.replaceWith(item);
+      item.classList.remove('dragging');
+      keyboardMode = false;
+      draggedItem = null;
+      updateOrder();
+      saveTasks();
+      item.focus();
+    }
+  });
+
+  // Reagiert auf das Abhaken einer Aufgabe
+  checkbox.addEventListener('change', () => {
+    if (checkbox.checked) {
+      task.isDone = true;
+      task.doneAt = new Date().toISOString();
+      item.remove();
+
+      saveTasks();
+
+      // Custom-Event ausloesen
+      document.dispatchEvent(new CustomEvent('task:done', { detail: task }));
+    }
+  });
+
+  const span = document.createElement('span');
+  span.textContent = task.text;
+  span.setAttribute('aria-label', 'Tasktext');
+
+  span.addEventListener('dblclick', () => {
+    const edit = document.createElement('input');
+    edit.type = 'text';
+    edit.value = task.text;
+    edit.maxLength = 200;
+    edit.className = 'edit-input';
+    edit.setAttribute('aria-label', 'Task bearbeiten');
+
+    const finish = () => {
+      const newText = edit.value.trim();
+      if (newText) {
+        task.text = newText;
+        saveTasks();
+        span.textContent = task.text;
+      }
+      edit.replaceWith(span);
+      span.focus();
+    };
+
+    const cancel = () => {
+      edit.replaceWith(span);
+      span.focus();
+    };
+
+    edit.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        finish();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      }
+    });
+
+    span.replaceWith(edit);
+    edit.focus();
+    edit.select();
+  });
+
+  const badge = document.createElement('span');
+  badge.className = `priority-badge priority-${task.priority}`;
+  badge.textContent = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
+
+  item.append(checkbox, span, badge);
+  return item;
+}
+
+function addTask(task) {
+  tasks.push(task);
+  const item = renderTask(task);
+  list.appendChild(item);
+  saveTasks();
+}
+
+// Aktualisiert die order-Eigenschaft aller offenen Aufgaben nach DOM-Reihenfolge
+function updateOrder() {
+  const items = Array.from(list.children);
+  items.forEach((li, idx) => {
+    const id = li.dataset.id;
+    const t = tasks.find(task => task.id === id);
+    if (t) t.order = idx;
+  });
+}
+
+// Zeigt alle offenen Aufgaben an
+function renderOpenTasks() {
+  list.innerHTML = '';
+  tasks
+    .filter(t => !t.isDone)
+    .sort((a, b) => a.order - b.order)
+    .forEach(t => list.appendChild(renderTask(t)));
+}
+
+// Zeigt erledigte Aufgaben sortiert nach doneAt absteigend
+function renderDoneTasks() {
+  doneList.innerHTML = '';
+  tasks
+    .filter(t => t.isDone)
+    .sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt))
+    .forEach(t => {
+      const li = document.createElement('li');
+      li.className = 'done-item';
+      const text = document.createElement('span');
+      text.textContent = t.text;
+      const badge = document.createElement('span');
+      badge.className = `priority-badge priority-${t.priority}`;
+      badge.textContent = t.priority.charAt(0).toUpperCase() + t.priority.slice(1);
+      const created = document.createElement('time');
+      created.dateTime = t.createdAt;
+      created.textContent = `erstellt: ${t.createdAt}`;
+      const done = document.createElement('time');
+      done.dateTime = t.doneAt;
+      done.textContent = `erledigt: ${t.doneAt}`;
+      // Icon zum Wiederherstellen der Aufgabe
+      const restore = document.createElement('button');
+      restore.type = 'button';
+      restore.className = 'restore-button';
+      restore.title = 'Wiederherstellen';
+      restore.textContent = '\u21BA'; // Pfeilsymbol
+
+      restore.addEventListener('click', () => {
+        t.isDone = false;
+        t.doneAt = null;
+
+        saveTasks();
+
+        // Custom-Event ausloesen
+        document.dispatchEvent(new CustomEvent('task:restore', { detail: t }));
+      });
+
+      li.append(text, badge, created, done, restore);
+      doneList.appendChild(li);
+    });
+}
+
+// Navigation zwischen den Routen
+function showRoute(route) {
+  if (route === '#/done') {
+    form.style.display = 'none';
+    list.hidden = true;
+    doneList.hidden = false;
+    linkOpen.classList.remove('active');
+    linkDone.classList.add('active');
+    renderDoneTasks();
+  } else {
+    form.style.display = 'flex';
+    list.hidden = false;
+    doneList.hidden = true;
+    linkOpen.classList.add('active');
+    linkDone.classList.remove('active');
+    renderOpenTasks();
+  }
+}
+
+function handleRoute() {
+  const route = location.hash || '#/';
+  showRoute(route);
+}
+
+// Rueckmeldung bei erledigten Aufgaben
+document.addEventListener('task:done', () => {
+  if (location.hash === '#/done') {
+    renderDoneTasks();
+  }
+});
+
+// Rueckmeldung bei wiederhergestellten Aufgaben
+document.addEventListener('task:restore', () => {
+  if (location.hash === '#/done') {
+    renderDoneTasks();
+  } else {
+    renderOpenTasks();
+  }
+});
+
+window.addEventListener('hashchange', handleRoute);
+window.addEventListener('load', () => {
+  loadTasks();
+  loadTheme();
+  handleRoute();
+});
+
+// Wechselt zwischen hellem und dunklem Theme
+themeToggle.addEventListener('click', () => {
+  const current = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+  localStorage.setItem('theme', next);
+});
+
+// Verhindert das Standardverhalten des Formulars und erstellt eine Aufgabe
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+
+  const text = input.value.trim();
+  if (!text) return;
+
+  const priority = prioritySelect.value;
+  const task = createTask(text, priority);
+  addTask(task);
+
+  // Eingabefeld leeren und Button deaktivieren
+  input.value = '';
+  prioritySelect.value = 'low';
+  addButton.disabled = true;
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,205 @@
+:root {
+  --bg-color: #f5f5f5;
+  --text-color: #000;
+  --item-bg: #fff;
+  --primary-color: #007bff;
+  --border-color: #ccc;
+  --badge-high: #dc3545;
+  --badge-medium: #ffc107;
+  --badge-low: #28a745;
+}
+
+:root[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #f5f5f5;
+  --item-bg: #1e1e1e;
+  --primary-color: #66b0ff;
+  --border-color: #555;
+}
+
+/* Grundlegendes Layout für die To-do App */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.todo-app {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--item-bg);
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  margin-top: 0;
+  text-align: center;
+}
+
+.todo-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.todo-input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--item-bg);
+  color: var(--text-color);
+}
+
+.edit-input {
+  flex: 1;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--item-bg);
+  color: var(--text-color);
+}
+
+.priority-select {
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--item-bg);
+  color: var(--text-color);
+}
+
+.add-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: var(--primary-color);
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.todo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.todo-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.task-item {
+  cursor: move;
+}
+
+/* Abstand fuer die Checkbox */
+.task-checkbox {
+  margin-right: 0.5rem;
+}
+
+/* Navigation zwischen den Routen */
+.nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.nav-link {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.nav-link.active {
+  font-weight: bold;
+}
+
+/* Liste fuer erledigte Aufgaben */
+.done-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.done-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.done-list time {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-color);
+  opacity: 0.7;
+}
+
+/* Button zum Wiederherstellen einer Aufgabe */
+.restore-button {
+  margin-left: auto;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--primary-color);
+  font-size: 1rem;
+}
+
+/* Farbige Badges fuer die Prioritaet */
+.priority-badge {
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #fff;
+}
+
+.priority-high {
+  background-color: var(--badge-high);
+}
+
+.priority-medium {
+  background-color: var(--badge-medium);
+  color: #000;
+}
+
+.priority-low {
+  background-color: var(--badge-low);
+}
+
+/* Drag-and-Drop Platzhalter */
+.placeholder {
+  border: 2px dashed var(--border-color);
+  height: 2rem;
+  margin: 0.5rem 0;
+}
+
+.task-item.dragging {
+  opacity: 0.5;
+}
+
+/* Header mit Theme-Toggle */
+.app-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.theme-toggle {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: var(--text-color);
+}


### PR DESCRIPTION
## Summary
- add a header with a theme toggle button
- implement CSS custom properties for dark and light themes
- persist chosen theme in `localStorage`

## Testing
- `npm run evaluate` *(fails: Cannot find module 'espree')*

------
https://chatgpt.com/codex/tasks/task_e_684b3086c15c8331a1e9dd1e6eef1c2e